### PR TITLE
Added additional directory to QT_TRANSLATIONS_DIR search

### DIFF
--- a/cmake/Libraries.cmake
+++ b/cmake/Libraries.cmake
@@ -38,9 +38,9 @@ IF(ANDROID)
 ENDIF()
 
 SET(QT_HOST_PREFIX ${_qt5Core_install_prefix})
-FOREACH(dest "" "share/qt" "share/qt5")
-	IF(EXISTS "${QT_HOST_PREFIX}/${dest}/translations")
-		SET(QT_TRANSLATIONS_DIR ${QT_HOST_PREFIX}/${dest}/translations)
+FOREACH(dest "${QT_HOST_PREFIX}" "${QT_HOST_PREFIX}/share/qt" "${QT_HOST_PREFIX}/share/qt5" "/usr/share/qt5")
+	IF(EXISTS "${dest}/translations")
+		SET(QT_TRANSLATIONS_DIR ${dest}/translations)
 	ENDIF()
 ENDFOREACH()
 


### PR DESCRIPTION
This adds the directory `/usr/share/qt5/translations` to the list of tested directories when searching the correct value for `QT_TRANSLATIONS_DIR`. This fixes the build on RedHat-based Linux distributions like Fedora.