### PR TITLE
Add support of MinGW on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,19 +2,23 @@ version: "{build}"
 
 environment:
   matrix:
-    - PlatformToolset: v140_xp
+    - PlatformToolset: mingw-w64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      QTPath: C:\Qt\5.9.2\mingw53_32
+
+    - PlatformToolset: v140
       platform: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       QTPath: C:\Qt\5.9.2\msvc2015_64
       ARCHI: amd64
 
-    - PlatformToolset: v140_xp
+    - PlatformToolset: v140
       platform: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       QTPath: C:\Qt\5.9.2\msvc2015
       ARCHI: x86
 
-    - PlatformToolset: v141_xp
+    - PlatformToolset: v141
       platform: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       QTPath: C:\Qt\5.9.2\msvc2017_64
@@ -25,8 +29,9 @@ configuration:
     #- Debug
 
 install:
-    - if "%PlatformToolset%"=="v140_xp" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
-    - if "%PlatformToolset%"=="v141_xp" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="mingw-w64" set PATH=C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+    - if "%PlatformToolset%"=="v140" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v141" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
 build:
     verbosity: minimal
@@ -37,8 +42,9 @@ before_build:
     Write-Output "Platform: $env:PLATFORM"
     $generator = switch ($env:PLATFORMTOOLSET)
     {
-        "v141_xp" {"Visual Studio 15 2017"}
-        "v140_xp" {"Visual Studio 14 2015"}
+        "v141"      {"Visual Studio 15 2017"}
+        "v140"      {"Visual Studio 14 2015"}
+        "mingw-w64" {"MinGW Makefiles"}
     }
     if ($env:PLATFORM -eq "x64")
     {
@@ -55,11 +61,11 @@ build_script:
     - ps: |
         # Use -DFORCE_LEGACY_OPENSSL=ON to build with the available openssl 1.0.2 of the appveyor build image
         # otherwise openssl 1.1.x is required with an additional download and build step
-        cmake -G "$generator" -T "$env:PLATFORMTOOLSET" -DCMAKE_BUILD_TYPE="$env:CONFIGURATION" -DFORCE_LEGACY_OPENSSL=ON ..
+        cmake -G "$generator" -DCMAKE_BUILD_TYPE="$env:CONFIGURATION" -DFORCE_LEGACY_OPENSSL=ON ..
         if ($LastExitCode -ne 0) {
             throw "Exec: $ErrorMessage"
         }
-        & cmake --build . --target package --config $env:CONFIGURATION -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+        & cmake --build . --target package --config $env:CONFIGURATION
         if ($LastExitCode -ne 0) {
             throw "Exec: $ErrorMessage"
         }


### PR DESCRIPTION
@chcg Could you look into this, too?

- Do you really need "_xp"? Qt5 do not support Windows XP anymore. Also it is not supported by AusweisApp2.
- "-- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"" cannot be used with MinGW. I don't see any difference with MSVC if I remove this.
- Is toolset necessary? Visual Studio 2015 and 2017 will use their default toolset if not defined by cmake.
