### PR TITLE
Build support for gcc < 5.x

### DIFF
--- a/src/card/base/CardConnectionWorker.cpp
+++ b/src/card/base/CardConnectionWorker.cpp
@@ -18,9 +18,9 @@ CardConnectionWorker::CardConnectionWorker(Reader* pReader)
 	, mReader(pReader)
 	, mSecureMessaging()
 {
-	connect(mReader, &Reader::fireCardInserted, this, &CardConnectionWorker::onReaderInfoChanged);
-	connect(mReader, &Reader::fireCardRemoved, this, &CardConnectionWorker::onReaderInfoChanged);
-	connect(mReader, &Reader::fireCardRetryCounterChanged, this, &CardConnectionWorker::onReaderInfoChanged);
+	connect(mReader.data(), &Reader::fireCardInserted, this, &CardConnectionWorker::onReaderInfoChanged);
+	connect(mReader.data(), &Reader::fireCardRemoved, this, &CardConnectionWorker::onReaderInfoChanged);
+	connect(mReader.data(), &Reader::fireCardRetryCounterChanged, this, &CardConnectionWorker::onReaderInfoChanged);
 }
 
 

--- a/src/qml/HistoryModel.cpp
+++ b/src/qml/HistoryModel.cpp
@@ -119,8 +119,8 @@ HistoryModel::HistoryModel(HistorySettings* pHistorySettings, QObject* pParent)
 	mFilterModel.setFilterCaseSensitivity(Qt::CaseInsensitive);
 	mNameFilterModel.setSourceModel(this);
 	mHistoryModelSearchFilter.setSourceModel(this);
-	connect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
-	connect(mHistorySettings, &HistorySettings::fireEnabledChanged, this, &HistoryModel::fireEnabledChanged);
+	connect(mHistorySettings.data(), &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
+	connect(mHistorySettings.data(), &HistorySettings::fireEnabledChanged, this, &HistoryModel::fireEnabledChanged);
 	connect(Env::getSingleton<ProviderConfiguration>(), &ProviderConfiguration::fireUpdated, this, &HistoryModel::onProvidersChanged);
 }
 
@@ -366,9 +366,9 @@ bool HistoryModel::removeRows(int pRow, int pCount, const QModelIndex& pParent)
 	entries.remove(pRow, pCount);
 
 	// disconnect the signal, otherwise this model gets reset
-	disconnect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
+	disconnect(mHistorySettings.data(), &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
 	mHistorySettings->setHistoryInfos(entries);
-	connect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
+	connect(mHistorySettings.data(), &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
 
 	mHistorySettings->save();
 

--- a/src/widget/DiagnosisGui.cpp
+++ b/src/widget/DiagnosisGui.cpp
@@ -47,7 +47,7 @@ void DiagnosisGui::activate()
 
 	auto context = new DiagnosisContext();
 	mDialog = new DiagnosisDialog(context, dialogParent);
-	connect(mDialog, &QDialog::finished, this, &DiagnosisGui::fireFinished);
+	connect(mDialog.data(), &QDialog::finished, this, &DiagnosisGui::fireFinished);
 	mDialog->show();
 
 	auto controller = new DiagnosisController(context, mDialog);

--- a/src/widget/SetupAssistantGui.cpp
+++ b/src/widget/SetupAssistantGui.cpp
@@ -36,7 +36,7 @@ void SetupAssistantGui::activate()
 		}
 
 		mWizard = new SetupAssistantWizard(dialogParent);
-		connect(mWizard, &SetupAssistantWizard::fireChangePinButtonClicked, this, &SetupAssistantGui::fireChangePinButtonClicked);
+		connect(mWizard.data(), &SetupAssistantWizard::fireChangePinButtonClicked, this, &SetupAssistantGui::fireChangePinButtonClicked);
 	}
 
 	mWizard->exec();

--- a/src/widget/step/StepChooseCardGui.cpp
+++ b/src/widget/step/StepChooseCardGui.cpp
@@ -39,7 +39,7 @@ StepChooseCardGui::StepChooseCardGui(const QSharedPointer<AuthContext>& pContext
 	mDeviceButton = mInformationMessageBox->addButton(tr("Settings"), QMessageBox::YesRole);
 	mDeviceButton->setFocus();
 
-	connect(mReaderDeviceGui, &ReaderDeviceGui::fireFinished, this, &StepChooseCardGui::onSubDialogFinished);
+	connect(mReaderDeviceGui.data(), &ReaderDeviceGui::fireFinished, this, &StepChooseCardGui::onSubDialogFinished);
 }
 
 


### PR DESCRIPTION
# Implicit casts of `QPointer<T>&` in signal/slot connection

There are many compile errors on implicit casts of `QPointer<T>&` in signal/slot connection when building with GCC < 5.x. The following error happens when building with GCC 4.8.4:
```
... no matching function for call to ‘QObject::connect(QPointer<T>&, ...)’
... no matching function for call to ‘QObject::disconnect(QPointer<T>&, ...)’
```
It's apparently a compiler bug that fixed in GCC 5.x and later. However, working around it is not very costly, and GCC 4.8 is supposed to should be supported. Similar report in Qt Bug Database [QTBUG-69512](https://bugreports.qt.io/browse/QTBUG-69512).

<details><summary><code>src/card/base/CardConnectionWorker.cpp</code> (Click to expand)</summary>
<pre>
/tmp/AusweisApp2/src/card/base/CardConnectionWorker.cpp: In constructor ‘governikus::CardConnectionWorker::CardConnectionWorker(governikus::Reader*)’:
/tmp/AusweisApp2/src/card/base/CardConnectionWorker.cpp:21:94: error: no matching function for call to ‘governikus::CardConnectionWorker::connect(QPointer<governikus::Reader>&, void (governikus::Reader::*)(const QString&), governikus::CardConnectionWorker* const, void (governikus::CardConnectionWorker::*)(const QString&))’
  connect(mReader, &Reader::fireCardInserted, this, &CardConnectionWorker::onReaderInfoChanged);
                                                                                              ^
/tmp/AusweisApp2/src/card/base/CardConnectionWorker.cpp:21:94: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::Reader>’
  connect(mReader, &Reader::fireCardInserted, this, &CardConnectionWorker::onReaderInfoChanged);
                                                                                              ^
</pre>...<pre>
/tmp/AusweisApp2/src/card/base/CardConnectionWorker.cpp:22:93: error: no matching function for call to ‘governikus::CardConnectionWorker::connect(QPointer<governikus::Reader>&, void (governikus::Reader::*)(const QString&), governikus::CardConnectionWorker* const, void (governikus::CardConnectionWorker::*)(const QString&))’
  connect(mReader, &Reader::fireCardRemoved, this, &CardConnectionWorker::onReaderInfoChanged);
                                                                                             ^
/tmp/AusweisApp2/src/card/base/CardConnectionWorker.cpp:22:93: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::Reader>’
  connect(mReader, &Reader::fireCardRemoved, this, &CardConnectionWorker::onReaderInfoChanged);
                                                                                             ^
</pre>...<pre>
/tmp/AusweisApp2/src/card/base/CardConnectionWorker.cpp:23:105: error: no matching function for call to ‘governikus::CardConnectionWorker::connect(QPointer<governikus::Reader>&, void (governikus::Reader::*)(const QString&), governikus::CardConnectionWorker* const, void (governikus::CardConnectionWorker::*)(const QString&))’
  connect(mReader, &Reader::fireCardRetryCounterChanged, this, &CardConnectionWorker::onReaderInfoChanged);
                                                                                                         ^
/tmp/AusweisApp2/src/card/base/CardConnectionWorker.cpp:23:105: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::Reader>’
  connect(mReader, &Reader::fireCardRetryCounterChanged, this, &CardConnectionWorker::onReaderInfoChanged);
                                                                                                         ^
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-gnu-zero-variadic-macro-arguments" [enabled by default]
</pre>
</details>
<details><summary><code>src/qml/HistoryModel.cpp</code> (Click to expand)</summary>
<pre>
/tmp/AusweisApp2/src/qml/HistoryModel.cpp: In constructor ‘governikus::HistoryModel::HistoryModel(governikus::HistorySettings*, QObject*)’:
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:122:115: error: no matching function for call to ‘governikus::HistoryModel::connect(QPointer<governikus::HistorySettings>&, void (governikus::HistorySettings::*)(), governikus::HistoryModel* const, void (governikus::HistoryModel::*)())’
  connect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
                                                                                                                   ^
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:122:115: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::HistorySettings>’
  connect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
                                                                                                                   ^
</pre>...<pre>
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:123:105: error: no matching function for call to ‘governikus::HistoryModel::connect(QPointer<governikus::HistorySettings>&, void (governikus::HistorySettings::*)(bool), governikus::HistoryModel* const, void (governikus::HistoryModel::*)(bool))’
  connect(mHistorySettings, &HistorySettings::fireEnabledChanged, this, &HistoryModel::fireEnabledChanged);
                                                                                                         ^
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:123:105: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::HistorySettings>’
  connect(mHistorySettings, &HistorySettings::fireEnabledChanged, this, &HistoryModel::fireEnabledChanged);
                                                                                                         ^
</pre>...<pre>
/tmp/AusweisApp2/src/qml/HistoryModel.cpp: In member function ‘virtual bool governikus::HistoryModel::removeRows(int, int, const QModelIndex&)’:
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:369:118: error: no matching function for call to ‘governikus::HistoryModel::disconnect(QPointer<governikus::HistorySettings>&, void (governikus::HistorySettings::*)(), governikus::HistoryModel* const, void (governikus::HistoryModel::*)())’
  disconnect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
                                                                                                                      ^
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:369:118: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::HistorySettings>’
  disconnect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
                                                                                                                      ^
</pre>...<pre>
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:371:115: error: no matching function for call to ‘governikus::HistoryModel::connect(QPointer<governikus::HistorySettings>&, void (governikus::HistorySettings::*)(), governikus::HistoryModel* const, void (governikus::HistoryModel::*)())’
  connect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
                                                                                                                   ^
/tmp/AusweisApp2/src/qml/HistoryModel.cpp:371:115: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::HistorySettings>’
  connect(mHistorySettings, &HistorySettings::fireHistoryInfosChanged, this, &HistoryModel::onHistoryEntriesChanged);
                                                                                                                   ^
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-gnu-zero-variadic-macro-arguments" [enabled by default]
</pre>
</details>
<details><summary><code>src/widget/DiagnosisGui.cpp</code> (Click to expand)</summary>
<pre>
/tmp/AusweisApp2/src/widget/DiagnosisGui.cpp: In member function ‘void governikus::DiagnosisGui::activate()’:
/tmp/AusweisApp2/src/widget/DiagnosisGui.cpp:50:72: error: no matching function for call to ‘governikus::DiagnosisGui::connect(QPointer<governikus::DiagnosisDialog>&, void (QDialog::*)(int), governikus::DiagnosisGui* const, void (governikus::DiagnosisGui::*)())’
  connect(mDialog, &QDialog::finished, this, &DiagnosisGui::fireFinished);
                                                                        ^
/tmp/AusweisApp2/src/widget/DiagnosisGui.cpp:50:72: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::DiagnosisDialog>’
  connect(mDialog, &QDialog::finished, this, &DiagnosisGui::fireFinished);
                                                                        ^
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-gnu-zero-variadic-macro-arguments" [enabled by default]
</pre>
</details>
<details><summary><code>src/widget/SetupAssistantGui.cpp</code> (Click to expand)</summary>
<pre>
/tmp/AusweisApp2/src/widget/SetupAssistantGui.cpp: In member function ‘void governikus::SetupAssistantGui::activate()’:
/tmp/AusweisApp2/src/widget/SetupAssistantGui.cpp:39:123: error: no matching function for call to ‘governikus::SetupAssistantGui::connect(QPointer<governikus::SetupAssistantWizard>&, void (governikus::SetupAssistantWizard::*)(), governikus::SetupAssistantGui* const, void (governikus::SetupAssistantGui::*)())’
   connect(mWizard, &SetupAssistantWizard::fireChangePinButtonClicked, this, &SetupAssistantGui::fireChangePinButtonClicked);
                                                                                                                           ^
/tmp/AusweisApp2/src/widget/SetupAssistantGui.cpp:39:123: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::SetupAssistantWizard>’
   connect(mWizard, &SetupAssistantWizard::fireChangePinButtonClicked, this, &SetupAssistantGui::fireChangePinButtonClicked);
                                                                                                                           ^
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-gnu-zero-variadic-macro-arguments" [enabled by default]
</pre>
</details>
<details><summary><code>src/widget/step/StepChooseCardGui.cpp</code> (Click to expand)</summary>
<pre>
/tmp/AusweisApp2/src/widget/step/StepChooseCardGui.cpp: In constructor ‘governikus::StepChooseCardGui::StepChooseCardGui(const QSharedPointer<governikus::AuthContext>&, governikus::AuthenticateStepsWidget*)’:
/tmp/AusweisApp2/src/widget/step/StepChooseCardGui.cpp:42:105: error: no matching function for call to ‘governikus::StepChooseCardGui::connect(QPointer<governikus::ReaderDeviceGui>&, void (governikus::ReaderDeviceGui::*)(), governikus::StepChooseCardGui* const, void (governikus::StepChooseCardGui::*)())’
  connect(mReaderDeviceGui, &ReaderDeviceGui::fireFinished, this, &StepChooseCardGui::onSubDialogFinished);
                                                                                                         ^
/tmp/AusweisApp2/src/widget/step/StepChooseCardGui.cpp:42:105: note:   mismatched types ‘const typename QtPrivate::FunctionPointer<Func>::Object*’ and ‘QPointer<governikus::ReaderDeviceGui>’
  connect(mReaderDeviceGui, &ReaderDeviceGui::fireFinished, this, &StepChooseCardGui::onSubDialogFinished);
                                                                                                         ^
At global scope:
cc1plus: warning: unrecognized command line option "-Wno-gnu-zero-variadic-macro-arguments" [enabled by default]
</pre>
</details>
