### PR TITLE
build with QT 5.11.1 + OpenSSL 1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ IF(POLICY CMP0071)
 	CMAKE_POLICY(SET CMP0071 NEW)
 ENDIF()
 
+IF(POLICY CMP0074)
+	CMAKE_POLICY(SET CMP0074 NEW)
+ENDIF()
+
 # "tools.only" can be defined to disable the normal build and enable
 # cmdline "tools" only. For example: "make format" or "make package_source"
 IF(tools.only)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,24 +4,28 @@ environment:
   matrix:
     - PlatformToolset: mingw-w64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      QTPath: C:\Qt\5.9\mingw53_32
+      QTPath: C:\Qt\5.11\mingw53_32
+      OPENSSLPath: C:\OpenSSL-v11-Win32
 
     - PlatformToolset: v140
       platform: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      QTPath: C:\Qt\5.9\msvc2015_64
+      QTPath: C:\Qt\5.11\msvc2015_64
+      OPENSSLPath: C:\OpenSSL-v11-Win64
       ARCHI: amd64
 
     - PlatformToolset: v140
       platform: Win32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      QTPath: C:\Qt\5.9\msvc2015
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      QTPath: C:\Qt\5.11\msvc2015
+      OPENSSLPath: C:\OpenSSL-v11-Win32
       ARCHI: x86
 
     - PlatformToolset: v141
       platform: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      QTPath: C:\Qt\5.9\msvc2017_64
+      QTPath: C:\Qt\5.11\msvc2017_64
+      OPENSSLPath: C:\OpenSSL-v11-Win64
       ARCHI: amd64
 
 configuration:
@@ -29,7 +33,7 @@ configuration:
     #- Debug
 
 install:
-    - if "%PlatformToolset%"=="mingw-w64" set PATH=C:\mingw-w64\i686-5.3.0-posix-dwarf-rt_v4-rev0\mingw32\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+    - if "%PlatformToolset%"=="mingw-w64" set PATH=C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin;%PATH:C:\Program Files\Git\usr\bin;=%
     - if "%PlatformToolset%"=="v140" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
     - if "%PlatformToolset%"=="v141" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
@@ -53,15 +57,17 @@ before_build:
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
-    - set PATH=%QTPATH%;%QTPATH%/bin;%PATH%
+    - set OPENSSL_ROOT=%OPENSSLPath%
+    - set PATH=%QTPATH%;%QTPATH%/bin;%OPENSSLPath%;%PATH%
     - echo %PATH%
+    - echo %OPENSSL_ROOT%
     - mkdir _build
     - cd _build
 
     - ps: |
         # Use -DFORCE_LEGACY_OPENSSL=ON to build with the available openssl 1.0.2 of the appveyor build image
         # otherwise openssl 1.1.x is required with an additional download and build step
-        cmake -G "$generator" -DCMAKE_BUILD_TYPE="$env:CONFIGURATION" -DFORCE_LEGACY_OPENSSL=ON ..
+        cmake -G "$generator" -DCMAKE_BUILD_TYPE="$env:CONFIGURATION" ..
         if ($LastExitCode -ne 0) {
             throw "Exec: $ErrorMessage"
         }


### PR DESCRIPTION
see https://ci.appveyor.com/project/chcg/ausweisapp2/build/1.14.3-81

updated appveyor.yml to build with 
QT 5.11.1 (https://www.appveyor.com/docs/build-environment/#qt)
OpenSSL 1.1.0i (https://www.appveyor.com/docs/build-environment/#tools)

travis failure is already part of current community branch