### PR TITLE
Fix issue with Linux desktop file compliance

### DIFF
--- a/resources/packaging/linux/AusweisApp2.desktop.in
+++ b/resources/packaging/linux/AusweisApp2.desktop.in
@@ -6,5 +6,6 @@ Icon=AusweisApp2
 StartupNotify=true
 Terminal=false
 Categories=Utility;Accessibility;
+GenericName=Authentication App
 Keywords=nPA,eID,eAT,Personalausweis,Aufenthaltstitel,Identity,Card
 Name=AusweisApp2

--- a/resources/packaging/linux/AusweisApp2.desktop.in
+++ b/resources/packaging/linux/AusweisApp2.desktop.in
@@ -5,6 +5,6 @@ Exec=@CMAKE_INSTALL_PREFIX@/bin/AusweisApp2
 Icon=AusweisApp2
 StartupNotify=true
 Terminal=false
-Categories=Network;Utility
+Categories=Utility;Accessibility;
 Keywords=nPA,eID,eAT,Personalausweis,Aufenthaltstitel,Identity,Card
 Name=AusweisApp2


### PR DESCRIPTION
The desktop file for Linux has two small issues.

One issue is an invalid value for "Categories" which is not allowed according to the specification. Secondly, the desktop file is missing the field "GenericName".

This pull request fixes both issues and makes the build succeed on openSUSE Tumbleweed.

See also: https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories