### PR TITLE
Fix appveyor of MSVC for __RPC_CALLEE

### DIFF
--- a/src/core/SignalHandler.h
+++ b/src/core/SignalHandler.h
@@ -45,7 +45,7 @@ class SignalHandler
 #elif defined(Q_OS_WIN)
 
 	private:
-		static BOOL __RPC_CALLEE ctrlHandler(DWORD pCtrlType);
+		static BOOL WINAPI ctrlHandler(DWORD pCtrlType);
 #endif
 
 	private Q_SLOTS:

--- a/src/core/SignalHandler_win.cpp
+++ b/src/core/SignalHandler_win.cpp
@@ -16,7 +16,7 @@ using namespace governikus;
 Q_DECLARE_LOGGING_CATEGORY(system)
 
 
-BOOL __RPC_CALLEE SignalHandler::ctrlHandler(DWORD pCtrlType)
+BOOL WINAPI SignalHandler::ctrlHandler(DWORD pCtrlType)
 {
 	qCWarning(system) << "Got signal:" << pCtrlType;
 


### PR DESCRIPTION
Looks like some versions do not accept __RPC_CALLEE.
Otherwise the clang compiler for Windows will output a warning
like this:

src\core\SignalHandler.cpp(46,25):  error: cast between incompatible calling conventions 'cdecl' and 'stdcall'; calls through this pointer may abort at runtime [-Werror,-Wcast-calling-convention]
           SetConsoleCtrlHandler(PHANDLER_ROUTINE(ctrlHandler), true);

\src\core\SignalHandler.h(48,15):  note: consider defining 'ctrlHandler' with the 'stdcall' calling convention
               static BOOL ctrlHandler(DWORD pCtrlType);
                           ^
                           __RPC_CALLEE