### PR TITLE
build with open ssl 1.1.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,27 +5,27 @@ environment:
     - PlatformToolset: mingw-w64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       QTPath: C:\Qt\5.11\mingw53_32
-      OPENSSLPath: C:\OpenSSL-v11-Win32
+      OPENSSLPath: C:\OpenSSL-v111-Win32
 
     - PlatformToolset: v140
       platform: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       QTPath: C:\Qt\5.11\msvc2015_64
-      OPENSSLPath: C:\OpenSSL-v11-Win64
+      OPENSSLPath: C:\OpenSSL-v111-Win64
       ARCHI: amd64
 
     - PlatformToolset: v140
       platform: Win32
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       QTPath: C:\Qt\5.11\msvc2015
-      OPENSSLPath: C:\OpenSSL-v11-Win32
+      OPENSSLPath: C:\OpenSSL-v111-Win32
       ARCHI: x86
 
     - PlatformToolset: v141
       platform: x64
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       QTPath: C:\Qt\5.11\msvc2017_64
-      OPENSSLPath: C:\OpenSSL-v11-Win64
+      OPENSSLPath: C:\OpenSSL-v111-Win64
       ARCHI: amd64
 
 configuration:


### PR DESCRIPTION
build with open ssl 1.1.1 like the available released SW, see https://www.appveyor.com/docs/windows-images-software/#tools for the exact version 1.1.1 for APPVEYOR_BUILD_WORKER_IMAGE VS2015 and 1.1.1a for VS2017

- failing win64 builds might be caused by the cmake version which is not yet 3.13.x, but 3.12.2