### PR TITLE
Fix path for loading files when build as an rpm package.

### DIFF
--- a/src/global/FileDestination.h
+++ b/src/global/FileDestination.h
@@ -29,7 +29,7 @@ class FileDestination
 			return QCoreApplication::applicationDirPath() + QStringLiteral("/../Resources");
 
 			#elif defined(Q_OS_LINUX) && defined(QT_NO_DEBUG)
-			return QString("/usr/share/AusweisApp2");
+			return QStringLiteral("/usr/share/AusweisApp2");
 
 			#else
 			return QCoreApplication::applicationDirPath();

--- a/src/global/FileDestination.h
+++ b/src/global/FileDestination.h
@@ -8,6 +8,7 @@
 
 #include <QCoreApplication>
 #include <QStringBuilder>
+#include <QLibraryInfo>
 
 namespace governikus
 {
@@ -27,6 +28,9 @@ class FileDestination
 			#elif defined(Q_OS_MACOS) && defined(QT_NO_DEBUG)
 			return QCoreApplication::applicationDirPath() + QStringLiteral("/../Resources");
 
+			#elif defined(Q_OS_LINUX) && defined(QT_NO_DEBUG)
+			return QString("/usr/share/AusweisApp2");
+
 			#else
 			return QCoreApplication::applicationDirPath();
 
@@ -37,7 +41,12 @@ class FileDestination
 	public:
 		static QString getPath(const QString& pFilename)
 		{
-			return getPath() % QLatin1Char('/') % pFilename;
+			#if defined(Q_OS_LINUX) && defined(QT_NO_DEBUG)
+			if (pFilename == QStringLiteral("translations"))
+				return QLibraryInfo::location(QLibraryInfo::TranslationsPath);	
+			else
+			#endif	
+				return getPath() % QLatin1Char('/') % pFilename;
 		}
 
 


### PR DESCRIPTION
- Load translation from Qt path on Linux(relase build)
- Load config.json from /usr/share/AusweisApp2 on Linux(relase build)
Both are needed, to package the app as an rpm package.