### PR TITLE
Fix crash when no tray is used

### DIFF
--- a/src/ui/common/TrayIcon.cpp
+++ b/src/ui/common/TrayIcon.cpp
@@ -117,7 +117,9 @@ void TrayIcon::hide()
 void TrayIcon::showMessage(const QString& pTitle, const QString& pMessage)
 {
 #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)
-	mTrayIcon->showMessage(pTitle, pMessage, mIcon, 3000);
+    if (mTrayIcon) {
+        mTrayIcon->showMessage(pTitle, pMessage, mIcon, 3000);
+    }
 #else
 	Q_UNUSED(pTitle);
 	Q_UNUSED(pMessage);


### PR DESCRIPTION
Obviously the mTrayIcon can be a nullptr in some situations.
