### PR TITLE
Better reflect current SOP with not activated ID

### DIFF
--- a/resources/translations/ausweisapp2_de.ts
+++ b/resources/translations/ausweisapp2_de.ts
@@ -472,9 +472,9 @@ INFO ANDROID IOS Generic progress message during PIN change process.</extracomme
         <translation>Bitte den Ausweis nicht bewegen...</translation>
     </message>
     <message>
-        <source>The online identification function of your ID card is not activated. Please contact the authority responsible for issuing your identification card to activate the online identification function.</source>
+        <source>The online identification function of your ID card is not activated. Please contact your responsible authority to activate the online identification function.</source>
         <extracomment>INFO ANDROID IOS The card communcation was aborted, the online identification functionality is deactivated and needs to be actived by the authorities.</extracomment>
-        <translation>Die Online-Ausweisfunktion Ihres Ausweises ist nicht aktiviert. Bitte wenden Sie sich an die Behörde, die Ihren Ausweis ausgegeben hat, um die Online-Ausweisfunktion zu aktivieren.</translation>
+        <translation>Die Online-Ausweisfunktion Ihres Ausweises ist nicht aktiviert. Bitte wenden Sie sich an Ihre zuständige Behörde, um die Online-Ausweisfunktion zu aktivieren.</translation>
     </message>
     <message>
         <source>Please observe the display of your card reader.</source>


### PR DESCRIPTION
This PR changes the message to the user what he should do when he is using a not online-activated ID.
Example: An ID is issued and the online function is not activated. The responsible regsitry office (Einwohnermeldeamt) is called A.
The user moves and another is now another registry office (B) is responsible for the user. The user wishes to user AusweisApp2 to authenticate.
In the current state the message can be understood to contact registry office A, which in this case is not responsible for the user.