### PR TITLE
Doxyfile: Exclude binary, CMake, libs, and test directories.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -11,7 +11,10 @@ OPTIMIZE_OUTPUT_C      = YES
 QT_AUTOBRIEF           = YES
 BUILTIN_STL_SUPPORT    = YES
 GENERATE_TREEVIEW      = YES
+FULL_PATH_NAMES        = YES
 STRIP_FROM_PATH        = @PROJECT_SOURCE_DIR@
+EXCLUDE_PATTERNS       = @PROJECT_BINARY_DIR@/* \
+                         */CMake* */libs/* */test/*
 
 SEARCHENGINE           = YES
 COLS_IN_ALPHA_INDEX    = 10


### PR DESCRIPTION
These directories do not contain any useful source files for the documentation of the internal API of AusweisApp2, and thus should not be included in its API documentation generated by Doxygen.

Additionally this comes in handy for distributing the API documentation architecture independent, when the name of the binary directory contains the name of the system's architecture the build is targeted to.

Also explicitly set the 'FULL_PATH_NAMES' parameter to 'YES', as this is needed for properly stripping and/or excluding the paths during generation of the documentation files.

Signed-off-by: Björn Esser <besser82@fedoraproject.org>