### PR TITLE
update to QT 5.15

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,21 +3,28 @@ version: "{build}"
 environment:
   matrix:
     - PlatformToolset: mingw-w64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      QTPath: C:\Qt\5.12\mingw73_64
+      platform: mingw-w64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      QTPath: C:\Qt\5.15\mingw81_64
       OPENSSLPath: C:\OpenSSL-v111-Win64
 
-    - PlatformToolset: v141
+    - PlatformToolset: mingw-w64_i686
+      platform: mingw-w64_i686
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      QTPath: C:\Qt\5.15\mingw81_32
+      OPENSSLPath: C:\OpenSSL-v111-Win32
+
+    - PlatformToolset: v142
       platform: Win32
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      QTPath: C:\Qt\5.12\msvc2017
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      QTPath: C:\Qt\5.15\msvc2019
       OPENSSLPath: C:\OpenSSL-v111-Win32
       ARCHI: x86
 
-    - PlatformToolset: v141
+    - PlatformToolset: v142
       platform: x64
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      QTPath: C:\Qt\5.12\msvc2017_64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      QTPath: C:\Qt\5.15\msvc2019_64
       OPENSSLPath: C:\OpenSSL-v111-Win64
       ARCHI: amd64
 
@@ -26,8 +33,10 @@ configuration:
     #- Debug
 
 install:
-    - if "%PlatformToolset%"=="mingw-w64" set PATH=C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+    - if "%PlatformToolset%"=="mingw-w64" set PATH=C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;%PATH:C:\Program Files\Git\usr\bin;=%
+    - if "%PlatformToolset%"=="mingw-w64_i686" set PATH=C:\mingw-w64\i686-8.1.0-posix-dwarf-rt_v6-rev0\mingw32\bin;%PATH:C:\Program Files\Git\usr\bin;=%
     - if "%PlatformToolset%"=="v141" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="v142" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
 build:
     verbosity: minimal
@@ -38,12 +47,17 @@ before_build:
     Write-Output "Platform: $env:PLATFORM"
     $generator = switch ($env:PLATFORMTOOLSET)
     {
+        "v142"      {"Visual Studio 16 2019"}
         "v141"      {"Visual Studio 15 2017"}
         "mingw-w64" {"MinGW Makefiles"}
+        "mingw-w64_i686" {"MinGW Makefiles"}
     }
-    if ($env:PLATFORM -eq "x64")
+    $cmake_generator_architecture = switch ($env:PLATFORM)
     {
-        $generator = "$generator Win64"
+        "x86"      {"Win32"}
+        "x64"      {"x64"}
+        "mingw-w64" {""}
+        "mingw-w64_i686" {""}
     }
 
 build_script:
@@ -56,7 +70,11 @@ build_script:
     - cd _build
 
     - ps: |
-        cmake -G "$generator" -DCMAKE_BUILD_TYPE="$env:CONFIGURATION" ..
+        if($cmake_generator_architecture) {
+            cmake -G "$generator" -A $cmake_generator_architecture -DCMAKE_BUILD_TYPE="$env:CONFIGURATION" ..
+        } else {
+            cmake -G "$generator" -DCMAKE_BUILD_TYPE="$env:CONFIGURATION" ..
+        }
         if ($LastExitCode -ne 0) {
             throw "Exec: $ErrorMessage"
         }


### PR DESCRIPTION
updated appveyor config to QT 5.15 on appveyor image for VS2019

see https://ci.appveyor.com/project/chcg/ausweisapp2/builds/36668197

With Mingw there is a compiler error at:

> C:\projects\ausweisapp2\src\core\controller\DiagnosisController_win.cpp:200:108: warning: cast from 'char*' to 'QUERY_SERVICE_CONFIG*' {aka '_QUERY_SERVICE_CONFIGW*'} increases required alignment of target type [-Wcast-align]
>     QUERY_SERVICE_CONFIG* serviceConfig = reinterpret_cast<QUERY_SERVICE_CONFIG*>(serviceConfigBuffer.data());
