### PR TITLE
Add StartupWMClass=AusweisApp2 to the desktop entry

### DIFF
--- a/resources/packaging/linux/com.governikus.ausweisapp2.desktop.in
+++ b/resources/packaging/linux/com.governikus.ausweisapp2.desktop.in
@@ -9,3 +9,4 @@ Categories=System;Security;
 GenericName=Authentication App
 Keywords=nPA,eID,eAT,Personalausweis,Aufenthaltstitel,Identity,Card
 Name=AusweisApp2
+StartupWMClass=AusweisApp2


### PR DESCRIPTION
Without StartupWMClass=AusweisApp2 in the desktop entry, while the application is running, it uses a generic icon in GNOME Shell Wayland and does not use its own icon.

With StartupWMClass=AusweisApp2, this enables GNOME Shell to map the application to its icon.