### PR TITLE
Beheben eines Rechtschreibfehlers in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ sind.
 
 Android
 ^^^^^^^
-Bei Android ist zu beachten, dass ein CMAKE_TOOLCHAIN_FILE angegeben werden muss.
+Bei Android ist zu beachten, dass eine CMAKE_TOOLCHAIN_FILE angegeben werden muss.
 
 ::
 


### PR DESCRIPTION
Diff:
```markdown
- Bei Android ist zu beachten, dass ein CMAKE_TOOLCHAIN_FILE angegeben werden muss.
+ Bei Android ist zu beachten, dass eine CMAKE_TOOLCHAIN_FILE angegeben werden muss.
```