### PR TITLE
Set Access-Control-Allow-Private-Network

### DIFF
--- a/src/network/HttpHandler.cpp
+++ b/src/network/HttpHandler.cpp
@@ -146,6 +146,7 @@ void HttpHandler::handleStatusRequest(StatusFormat pStatusFormat, const QSharedP
 
 	HttpResponse response(HTTP_STATUS_OK);
 	response.setHeader(QByteArrayLiteral("Access-Control-Allow-Origin"), QByteArrayLiteral("*"));
+	response.setHeader(QByteArrayLiteral("Access-Control-Allow-Private-Network"), QByteArrayLiteral("true"));
 	switch (pStatusFormat)
 	{
 		case StatusFormat::PLAIN:


### PR DESCRIPTION
Set Access-Control-Allow-Private-Network in the `eID-Client?status` response, because it is required by (at least) Chrome:

> Chrome is deprecating direct access to private network endpoints from public websites as part of the [Private Network Access](https://wicg.github.io/private-network-access/) (PNA) specification.
>
> Chrome will start sending a CORS preflight request ahead of any [private network request](https://developer.chrome.com/blog/private-network-access-preflight/#what-is-private-network-access) for a subresource, which asks for explicit permission from the target server. This preflight request will carry a new header, Access-Control-Request-Private-Network: true, and the response to it must carry a corresponding header, Access-Control-Allow-Private-Network: true.

Relevant Links: [developer.chrome.com/blog/private-network-access-preflight](https://developer.chrome.com/blog/private-network-access-preflight/)