### PR TITLE
Android: Hack maxAdpuLength to 500 Bytes instead of OS reported value.

### DIFF
--- a/libs/patches/qt-connectivity-0001-ExtendedLengthApduSupportHack.patch
+++ b/libs/patches/qt-connectivity-0001-ExtendedLengthApduSupportHack.patch
@@ -1,0 +1,11 @@
+--- x/qtconnectivity/src/nfc/qnearfieldtarget_android.cpp	2023-02-22 22:01:06.387856631 +0100
++++ y/qtconnectivity/src/nfc/qnearfieldtarget_android.cpp	2023-02-23 07:42:58.722535032 +0100
+@@ -143,7 +143,7 @@
+ {
+     QJniObject tagTech;
+     if (techList.contains(ISODEPTECHNOLOGY))
++        return 500; // kleinerm changed to 500, was: tagTech = getTagTechnology(ISODEPTECHNOLOGY);
+-        tagTech = getTagTechnology(ISODEPTECHNOLOGY);
+     else if (techList.contains(NFCATECHNOLOGY))
+         tagTech = getTagTechnology(NFCATECHNOLOGY);
+     else if (techList.contains(NFCBTECHNOLOGY))

--- a/src/card/nfc/NfcReader.cpp
+++ b/src/card/nfc/NfcReader.cpp
@@ -40,6 +40,14 @@ void NfcReader::targetDetected(QNearFieldTarget* pTarget)
 	}
 
 	int length = pTarget->maxCommandLength();
+
+	if (length < 500)
+	{
+		qCDebug(card_nfc) << "ExtendedLengthApduSupport missing. MaxTransceiveLength:" << length;
+		length = 500;
+		qCDebug(card_nfc) << "kleinerm hack. Overriding MaxTransceiveLength to:" << length;
+	}
+
 	setInfoMaxApduLength(length);
 	if (getReaderInfo().insufficientApduLength())
 	{


### PR DESCRIPTION
As 500 Bytes is the minimum length for AusweisApp2 to supposedly work.

This is less of a proper pull request than a proposal or feature request to add something like this properly, or maybe "as is" in an "unsupported" or "experimental" build or branch of AusweisApp2, maybe even via an alternative repository like f-droid?

Many modern Android Smartphones may have NFC chips and Android versions that are perfectly capable of supporting a maxAdpuLength of 500 Bytes and more, as required for AusweisApp2 to fully function. But mistakes by the device vendor in their firmware configuration cause the Android OS to falsely report a maxAdpuLength of only around 200 Bytes. This prevents users from using the Smartphone with their eID Personalausweis.

E.g., my new Motorola Moto G-42 introduced in summer 2022 seems to have a NFC chip that can do more than 200 Bytes, but the vendors Android config file encodes the ~200 Bytes default limit from the AOSP, a mistake reported to Motorola long ago, but so far uncorrected.

My proposal would be to have a proper opt-in option AusweisApp2's settings, or an alternate build (f-droid?) where the check for max transceive size is disabled and at least 500 Bytes are reported back, so the app tries to do the full Adpu command exchange. If it works, great! If not, the user was informed that when using this alternate build of the app on truly inapable hw+firmware things may go haywire.

I tried to test this with my Moto G42, but was only half successful in testing, because I didn't manage to build AusweisApp2 properly and consistently.

My first attempt with only the hacked `NfcReader::targetDetected(QNearFieldTarget* pTarget)` function in `src/card/nfc/NfcReader.cpp` was successful in the sense that my new Personalausweis and phone passed the basic compatibility check and I was able to change my transport PIN to a proper PIN. :)

More advanced functionality failed because of the additional length checks inside QT's qtconnectivity qnearfieldtarget_android.cpp file for reporting max Adpu length.

So two weeks later I added the QT patch which is part of this commit, which should take care of that problem. Unfortunately i couldn't test it, because i never managed to build the apk of the app again due to all kind of build problems and dependency problems, not due to this patch itself. Building following the build instructions in AusweisApp2 failed, as did an attempt with android-build-box, and a local f-droid setup on Ubuntu 20.04 and also with the f-droid docker container with the latest f-droid server tools. Every attempt was a failure for different reasons from being low on disc space - the double build of QT6 qt-host and qt target device versions requires almost 30 GB, a dying disc drive, bugs in outdated cmake versions, problems with incompatibilities or problems with different Android SDK's, NDK's, build tool versions, gradle and gradle plugin versions... - I also found now bug reports against F-droid which suggest the build of latest AusweissApp2 versions with QT-6 is broken on f-droid. I'm not familiar enough with the complex Android build system and now decided to give up on building and testing this hacked version of AusweisApp2.

But I think having such a dedicated hacked version of AusweisApp2 available as an unsupported build or f-droid variant, or properly integrating such a "ignore system reported max Adpu length limit" option into the apps settings GUI would be valuable. Many owners of existing Android phones with vendor misconfigured firmware and bad vendor customer support might be able to enjoy use of their eID with their existing phones instead of having to throw away their phones or having to buy a dedicated NFC USB reader - a waste of the citizens money and e-waste for the environment.