### PR TITLE
.clang-tidy: remove llvm-libc specific checks (this isn't llvm-libc code…)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,7 @@ Checks: '
        ,-readability-convert-member-functions-to-static,
        ,-readability-redundant-member-init,
        ,-readability-implicit-bool-cast,
+       ,-llvmlibc-*,
 '
 
 WarningsAsErrors: ''


### PR DESCRIPTION
This disables a lot of `declaration must be declared within the '__llvm_libc' namespace` diagnostics. Which is desirable, since this code really isn't LLVM's libc.
