### PR TITLE
Fix compilation failure on openSUSE Tumbleweed (10/2023)

### DIFF
--- a/resources/qml/Governikus/Global/TintableIcon.qml
+++ b/resources/qml/Governikus/Global/TintableIcon.qml
@@ -16,7 +16,6 @@ Item {
 	property alias sourceSize: image.sourceSize
 	property color tintColor: Style.color.primary_text
 	property bool tintEnabled: true
-	property alias transformOrigin: image.transformOrigin
 
 	implicitHeight: image.implicitHeight
 	implicitWidth: image.implicitWidth
@@ -26,6 +25,7 @@ Item {
 		anchors.fill: parent
 		asynchronous: true
 		fillMode: Image.PreserveAspectFit
+		transformOrigin: root.transformOrigin
 		layer.enabled: root.tintEnabled && GraphicsInfo.api !== GraphicsInfo.Software
 
 		layer.effect: ShaderEffect {

--- a/src/card/pcsc/PcscUtils.h
+++ b/src/card/pcsc/PcscUtils.h
@@ -43,7 +43,7 @@ using PCSC_CHAR = char;
 using PCSC_CHAR_PTR = char*;
 using PCSC_CUCHAR_PTR = const uchar*;
 using PCSC_INT = DWORD;
-using PCSC_RETURNCODE = LONG;
+using PCSC_RETURNCODE = qint64;
 using PCSC_UCHAR_PTR = uchar*;
 #endif
 


### PR DESCRIPTION
PcscUtils: Using LONG (long) as the underlying type for enum PcscReturnCode caused an ambiguity when resolving QDataStream operators. Therefore, now explicitly use qint32. Before, on 64-bit platforms, a 64-bit signed int was used and on 32-bit platforms, a 32-bit signed int was used. Because the return-code constants intentionally use an overfloating 0x80000000 representation, the returnCode() cast-macro is now also needed on other Unix-likes, so use Q_OS_UNIX instead of Q_OS_MACOS which also has Q_OS_UNIX defined.